### PR TITLE
allow more flexible dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 numpy>=1.19.1
 torchvision>=0.7.0
 torch>=1.6.0
-gensim==3.8.3
-sentence-transformers==1.1.1
-wordcloud==1.8.1
-matplotlib==3.1.3
-tqdm==4.56.0
-scipy==1.4.1
+gensim>=3.8.3
+sentence-transformers>=1.1.1
+wordcloud>=1.8.1
+matplotlib>=3.1.3
+tqdm>=4.56.0
+scipy>=1.4.1
 


### PR DESCRIPTION
currently conflicts can arise when using contextualized-topic-models with other libraries requiring newer versions of libraries. This puts a lower bound on dep versions.