### PR TITLE
CTM Memory and Speed Improvements

### DIFF
--- a/contextualized_topic_models/models/ctm.py
+++ b/contextualized_topic_models/models/ctm.py
@@ -554,7 +554,7 @@ class CTM:
             num_workers=self.num_data_loader_workers,
         )
         with torch.no_grad():
-            for batch_samples in tqdm(loader, position=0, leave=True):
+            for batch_samples in tqdm(loader):
                 # batch_size x vocab_size
                 X_bow = batch_samples["X_bow"]
                 X_bow = X_bow.reshape(X_bow.shape[0], -1)

--- a/contextualized_topic_models/models/ctm.py
+++ b/contextualized_topic_models/models/ctm.py
@@ -418,7 +418,7 @@ class CTM:
             )
 
         pbar.close()
-        if do_train_predictions
+        if do_train_predictions:
             self.training_doc_topic_distributions = self.get_doc_topic_distribution(
                 train_dataset, n_samples
             )

--- a/contextualized_topic_models/models/ctm.py
+++ b/contextualized_topic_models/models/ctm.py
@@ -294,7 +294,7 @@ class CTM:
         :param patience: How long to wait after last time validation loss improved. Default: 5
         :param delta: Minimum change in the monitored quantity to qualify as an improvement. Default: 0
         :param n_samples: int, number of samples of the document topic distribution (default: 20)
-
+        :param do_train_predictions: bool, whether to compute train predictions after fitting (default: True)
         """
         # Print settings to output file
         if verbose:
@@ -418,7 +418,7 @@ class CTM:
             )
 
         pbar.close()
-        if do_train_predictions:
+        if do_train_predictions
             self.training_doc_topic_distributions = self.get_doc_topic_distribution(
                 train_dataset, n_samples
             )

--- a/contextualized_topic_models/models/ctm.py
+++ b/contextualized_topic_models/models/ctm.py
@@ -12,7 +12,9 @@ from torch import optim
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 from torch.utils.data import DataLoader
 from tqdm import tqdm
-from contextualized_topic_models.utils.early_stopping.early_stopping import EarlyStopping
+from contextualized_topic_models.utils.early_stopping.early_stopping import (
+    EarlyStopping,
+)
 from contextualized_topic_models.networks.decoding_network import DecoderNetwork
 
 
@@ -42,42 +44,63 @@ class CTM:
 
     """
 
-    def __init__(self, bow_size, contextual_size, inference_type="combined", n_components=10, model_type='prodLDA',
-                 hidden_sizes=(100, 100), activation='softplus', dropout=0.2, learn_priors=True, batch_size=64,
-                 lr=2e-3, momentum=0.99, solver='adam', num_epochs=100, reduce_on_plateau=False,
-                 num_data_loader_workers=mp.cpu_count(), label_size=0, loss_weights=None):
+    def __init__(
+        self,
+        bow_size,
+        contextual_size,
+        inference_type="combined",
+        n_components=10,
+        model_type="prodLDA",
+        hidden_sizes=(100, 100),
+        activation="softplus",
+        dropout=0.2,
+        learn_priors=True,
+        batch_size=64,
+        lr=2e-3,
+        momentum=0.99,
+        solver="adam",
+        num_epochs=100,
+        reduce_on_plateau=False,
+        num_data_loader_workers=mp.cpu_count(),
+        label_size=0,
+        loss_weights=None,
+    ):
 
         self.device = (
-                torch.device("cuda")
-                if torch.cuda.is_available()
-                else torch.device("cpu")
-            )
+            torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+        )
 
         if self.__class__.__name__ == "CTM":
             raise Exception("You cannot call this class. Use ZeroShotTM or CombinedTM")
 
-        assert isinstance(bow_size, int) and bow_size > 0, \
-            "input_size must by type int > 0."
-        assert isinstance(n_components, int) and bow_size > 0, \
-            "n_components must by type int > 0."
-        assert model_type in ['LDA', 'prodLDA'], \
-            "model must be 'LDA' or 'prodLDA'."
-        assert isinstance(hidden_sizes, tuple), \
-            "hidden_sizes must be type tuple."
-        assert activation in ['softplus', 'relu'], \
-            "activation must be 'softplus' or 'relu'."
+        assert (
+            isinstance(bow_size, int) and bow_size > 0
+        ), "input_size must by type int > 0."
+        assert (
+            isinstance(n_components, int) and bow_size > 0
+        ), "n_components must by type int > 0."
+        assert model_type in ["LDA", "prodLDA"], "model must be 'LDA' or 'prodLDA'."
+        assert isinstance(hidden_sizes, tuple), "hidden_sizes must be type tuple."
+        assert activation in [
+            "softplus",
+            "relu",
+        ], "activation must be 'softplus' or 'relu'."
         assert dropout >= 0, "dropout must be >= 0."
         assert isinstance(learn_priors, bool), "learn_priors must be boolean."
-        assert isinstance(batch_size, int) and batch_size > 0, \
-            "batch_size must be int > 0."
+        assert (
+            isinstance(batch_size, int) and batch_size > 0
+        ), "batch_size must be int > 0."
         assert lr > 0, "lr must be > 0."
-        assert isinstance(momentum, float) and 0 < momentum <= 1, \
-            "momentum must be 0 < float <= 1."
-        assert solver in ['adam', 'sgd'], "solver must be 'adam' or 'sgd'."
-        assert isinstance(reduce_on_plateau, bool), \
-            "reduce_on_plateau must be type bool."
-        assert isinstance(num_data_loader_workers, int) and num_data_loader_workers >= 0, \
-            "num_data_loader_workers must by type int >= 0. set 0 if you are using windows"
+        assert (
+            isinstance(momentum, float) and 0 < momentum <= 1
+        ), "momentum must be 0 < float <= 1."
+        assert solver in ["adam", "sgd"], "solver must be 'adam' or 'sgd'."
+        assert isinstance(
+            reduce_on_plateau, bool
+        ), "reduce_on_plateau must be type bool."
+        assert (
+            isinstance(num_data_loader_workers, int) and num_data_loader_workers >= 0
+        ), "num_data_loader_workers must by type int >= 0. set 0 if you are using windows"
 
         self.bow_size = bow_size
         self.n_components = n_components
@@ -102,25 +125,36 @@ class CTM:
             self.weights = {"beta": 1}
 
         self.model = DecoderNetwork(
-            bow_size, self.contextual_size, inference_type, n_components, model_type, hidden_sizes, activation,
-            dropout, learn_priors, label_size=label_size)
+            bow_size,
+            self.contextual_size,
+            inference_type,
+            n_components,
+            model_type,
+            hidden_sizes,
+            activation,
+            dropout,
+            learn_priors,
+            label_size=label_size,
+        )
 
         self.early_stopping = None
 
         # init optimizer
-        if self.solver == 'adam':
+        if self.solver == "adam":
             self.optimizer = optim.Adam(
-                self.model.parameters(), lr=lr, betas=(self.momentum, 0.99))
-        elif self.solver == 'sgd':
+                self.model.parameters(), lr=lr, betas=(self.momentum, 0.99)
+            )
+        elif self.solver == "sgd":
             self.optimizer = optim.SGD(
-                self.model.parameters(), lr=lr, momentum=self.momentum)
+                self.model.parameters(), lr=lr, momentum=self.momentum
+            )
 
         # init lr scheduler
         if self.reduce_on_plateau:
             self.scheduler = ReduceLROnPlateau(self.optimizer, patience=10)
 
         # performance attributes
-        self.best_loss_train = float('inf')
+        self.best_loss_train = float("inf")
 
         # training attributes
         self.model_dir = None
@@ -140,27 +174,34 @@ class CTM:
 
         self.model = self.model.to(self.device)
 
-    def _loss(self, inputs, word_dists, prior_mean, prior_variance,
-              posterior_mean, posterior_variance, posterior_log_variance):
+    def _loss(
+        self,
+        inputs,
+        word_dists,
+        prior_mean,
+        prior_variance,
+        posterior_mean,
+        posterior_variance,
+        posterior_log_variance,
+    ):
 
         # KL term
         # var division term
         var_division = torch.sum(posterior_variance / prior_variance, dim=1)
         # diff means term
         diff_means = prior_mean - posterior_mean
-        diff_term = torch.sum(
-            (diff_means * diff_means) / prior_variance, dim=1)
+        diff_term = torch.sum((diff_means * diff_means) / prior_variance, dim=1)
         # logvar det division term
-        logvar_det_division = \
-            prior_variance.log().sum() - posterior_log_variance.sum(dim=1)
+        logvar_det_division = prior_variance.log().sum() - posterior_log_variance.sum(
+            dim=1
+        )
         # combine terms
-        KL = 0.5 * (
-            var_division + diff_term - self.n_components + logvar_det_division)
+        KL = 0.5 * (var_division + diff_term - self.n_components + logvar_det_division)
 
         # Reconstruction term
         RL = -torch.sum(inputs * torch.log(word_dists + 1e-10), dim=1)
 
-        #loss = self.weights["beta"]*KL + RL
+        # loss = self.weights["beta"]*KL + RL
 
         return KL, RL
 
@@ -172,9 +213,9 @@ class CTM:
 
         for batch_samples in loader:
             # batch_size x vocab_size
-            X_bow = batch_samples['X_bow']
+            X_bow = batch_samples["X_bow"]
             X_bow = X_bow.reshape(X_bow.shape[0], -1)
-            X_contextual = batch_samples['X_contextual']
+            X_contextual = batch_samples["X_contextual"]
 
             if "labels" in batch_samples.keys():
                 labels = batch_samples["labels"]
@@ -189,21 +230,36 @@ class CTM:
 
             # forward pass
             self.model.zero_grad()
-            prior_mean, prior_variance, posterior_mean, posterior_variance,\
-            posterior_log_variance, word_dists, estimated_labels = self.model(X_bow, X_contextual, labels)
+            (
+                prior_mean,
+                prior_variance,
+                posterior_mean,
+                posterior_variance,
+                posterior_log_variance,
+                word_dists,
+                estimated_labels,
+            ) = self.model(X_bow, X_contextual, labels)
 
             # backward pass
             kl_loss, rl_loss = self._loss(
-                X_bow, word_dists, prior_mean, prior_variance,
-                posterior_mean, posterior_variance, posterior_log_variance)
+                X_bow,
+                word_dists,
+                prior_mean,
+                prior_variance,
+                posterior_mean,
+                posterior_variance,
+                posterior_log_variance,
+            )
 
-            loss = self.weights["beta"]*kl_loss + rl_loss
+            loss = self.weights["beta"] * kl_loss + rl_loss
             loss = loss.sum()
 
             if labels is not None:
                 target_labels = torch.argmax(labels, 1)
 
-                label_loss = torch.nn.CrossEntropyLoss()(estimated_labels, target_labels)
+                label_loss = torch.nn.CrossEntropyLoss()(
+                    estimated_labels, target_labels
+                )
                 loss += label_loss
 
             loss.backward()
@@ -217,8 +273,17 @@ class CTM:
 
         return samples_processed, train_loss
 
-    def fit(self, train_dataset, validation_dataset=None, save_dir=None, verbose=False, patience=5, delta=0,
-            n_samples=20):
+    def fit(
+        self,
+        train_dataset,
+        validation_dataset=None,
+        save_dir=None,
+        verbose=False,
+        patience=5,
+        delta=0,
+        n_samples=20,
+        do_train_predictions=True,
+    ):
         """
         Train the CTM model.
 
@@ -233,7 +298,8 @@ class CTM:
         """
         # Print settings to output file
         if verbose:
-            print("Settings: \n\
+            print(
+                "Settings: \n\
                    N Components: {}\n\
                    Topic Prior Mean: {}\n\
                    Topic Prior Variance: {}\n\
@@ -246,20 +312,36 @@ class CTM:
                    Momentum: {}\n\
                    Reduce On Plateau: {}\n\
                    Save Dir: {}".format(
-                self.n_components, 0.0,
-                1. - (1. / self.n_components), self.model_type,
-                self.hidden_sizes, self.activation, self.dropout, self.learn_priors,
-                self.lr, self.momentum, self.reduce_on_plateau, save_dir))
+                    self.n_components,
+                    0.0,
+                    1.0 - (1.0 / self.n_components),
+                    self.model_type,
+                    self.hidden_sizes,
+                    self.activation,
+                    self.dropout,
+                    self.learn_priors,
+                    self.lr,
+                    self.momentum,
+                    self.reduce_on_plateau,
+                    save_dir,
+                )
+            )
 
         self.model_dir = save_dir
         self.idx2token = train_dataset.idx2token
         train_data = train_dataset
         self.validation_data = validation_dataset
         if self.validation_data is not None:
-            self.early_stopping = EarlyStopping(patience=patience, verbose=verbose, path=save_dir, delta=delta)
+            self.early_stopping = EarlyStopping(
+                patience=patience, verbose=verbose, path=save_dir, delta=delta
+            )
         train_loader = DataLoader(
-            train_data, batch_size=self.batch_size, shuffle=True,
-            num_workers=self.num_data_loader_workers, drop_last=True)
+            train_data,
+            batch_size=self.batch_size,
+            shuffle=True,
+            num_workers=self.num_data_loader_workers,
+            drop_last=True,
+        )
 
         # init training variables
         train_loss = 0
@@ -277,8 +359,13 @@ class CTM:
             pbar.update(1)
 
             if self.validation_data is not None:
-                validation_loader = DataLoader(self.validation_data, batch_size=self.batch_size, shuffle=True,
-                                               num_workers=self.num_data_loader_workers, drop_last=True)
+                validation_loader = DataLoader(
+                    self.validation_data,
+                    batch_size=self.batch_size,
+                    shuffle=True,
+                    num_workers=self.num_data_loader_workers,
+                    drop_last=True,
+                )
                 # train epoch
                 s = datetime.datetime.now()
                 val_samples_processed, val_loss = self._validation(validation_loader)
@@ -286,13 +373,28 @@ class CTM:
 
                 # report
                 if verbose:
-                    print("Epoch: [{}/{}]\tSamples: [{}/{}]\tValidation Loss: {}\tTime: {}".format(
-                        epoch + 1, self.num_epochs, val_samples_processed,
-                        len(self.validation_data) * self.num_epochs, val_loss, e - s))
+                    print(
+                        "Epoch: [{}/{}]\tSamples: [{}/{}]\tValidation Loss: {}\tTime: {}".format(
+                            epoch + 1,
+                            self.num_epochs,
+                            val_samples_processed,
+                            len(self.validation_data) * self.num_epochs,
+                            val_loss,
+                            e - s,
+                        )
+                    )
 
-                pbar.set_description("Epoch: [{}/{}]\t Seen Samples: [{}/{}]\tTrain Loss: {}\tValid Loss: {}\tTime: {}".format(
-                    epoch + 1, self.num_epochs, samples_processed,
-                    len(train_data) * self.num_epochs, train_loss, val_loss, e - s))
+                pbar.set_description(
+                    "Epoch: [{}/{}]\t Seen Samples: [{}/{}]\tTrain Loss: {}\tValid Loss: {}\tTime: {}".format(
+                        epoch + 1,
+                        self.num_epochs,
+                        samples_processed,
+                        len(train_data) * self.num_epochs,
+                        train_loss,
+                        val_loss,
+                        e - s,
+                    )
+                )
 
                 self.early_stopping(val_loss, self)
                 if self.early_stopping.early_stop:
@@ -304,12 +406,22 @@ class CTM:
                 self.best_components = self.model.beta
                 if save_dir is not None:
                     self.save(save_dir)
-            pbar.set_description("Epoch: [{}/{}]\t Seen Samples: [{}/{}]\tTrain Loss: {}\tTime: {}".format(
-                epoch + 1, self.num_epochs, samples_processed,
-                len(train_data) * self.num_epochs, train_loss, e - s))
+            pbar.set_description(
+                "Epoch: [{}/{}]\t Seen Samples: [{}/{}]\tTrain Loss: {}\tTime: {}".format(
+                    epoch + 1,
+                    self.num_epochs,
+                    samples_processed,
+                    len(train_data) * self.num_epochs,
+                    train_loss,
+                    e - s,
+                )
+            )
 
         pbar.close()
-        self.training_doc_topic_distributions = self.get_doc_topic_distribution(train_dataset, n_samples)
+        if do_train_predictions:
+            self.training_doc_topic_distributions = self.get_doc_topic_distribution(
+                train_dataset, n_samples
+            )
 
     def _validation(self, loader):
         """Validation epoch."""
@@ -318,9 +430,9 @@ class CTM:
         samples_processed = 0
         for batch_samples in loader:
             # batch_size x vocab_size
-            X_bow = batch_samples['X_bow']
+            X_bow = batch_samples["X_bow"]
             X_bow = X_bow.reshape(X_bow.shape[0], -1)
-            X_contextual = batch_samples['X_contextual']
+            X_contextual = batch_samples["X_contextual"]
 
             if "labels" in batch_samples.keys():
                 labels = batch_samples["labels"]
@@ -335,19 +447,34 @@ class CTM:
 
             # forward pass
             self.model.zero_grad()
-            prior_mean, prior_variance, posterior_mean, posterior_variance, posterior_log_variance, word_dists, \
-            estimated_labels =\
-                self.model(X_bow, X_contextual, labels)
+            (
+                prior_mean,
+                prior_variance,
+                posterior_mean,
+                posterior_variance,
+                posterior_log_variance,
+                word_dists,
+                estimated_labels,
+            ) = self.model(X_bow, X_contextual, labels)
 
-            kl_loss, rl_loss = self._loss(X_bow, word_dists, prior_mean, prior_variance,
-                              posterior_mean, posterior_variance, posterior_log_variance)
+            kl_loss, rl_loss = self._loss(
+                X_bow,
+                word_dists,
+                prior_mean,
+                prior_variance,
+                posterior_mean,
+                posterior_variance,
+                posterior_log_variance,
+            )
 
-            loss = self.weights["beta"]*kl_loss + rl_loss
+            loss = self.weights["beta"] * kl_loss + rl_loss
             loss = loss.sum()
 
             if labels is not None:
                 target_labels = torch.argmax(labels, 1)
-                label_loss = torch.nn.CrossEntropyLoss()(estimated_labels, target_labels)
+                label_loss = torch.nn.CrossEntropyLoss()(
+                    estimated_labels, target_labels
+                )
                 loss += label_loss
 
             # compute train loss
@@ -379,44 +506,80 @@ class CTM:
         self.model.eval()
 
         loader = DataLoader(
-            dataset, batch_size=self.batch_size, shuffle=False,
-            num_workers=self.num_data_loader_workers)
-        pbar = tqdm(n_samples, position=0, leave=True)
+            dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=self.num_data_loader_workers,
+        )
         final_thetas = []
-        for sample_index in range(n_samples):
-            with torch.no_grad():
-                collect_theta = []
+        with torch.no_grad():
+            for batch_samples in tqdm(loader, position=0, leave=True):
+                # batch_size x vocab_size
+                X_bow = batch_samples["X_bow"]
+                X_bow = X_bow.reshape(X_bow.shape[0], -1)
+                X_contextual = batch_samples["X_contextual"]
 
-                for batch_samples in loader:
-                    # batch_size x vocab_size
-                    X_bow = batch_samples['X_bow']
-                    X_bow = X_bow.reshape(X_bow.shape[0], -1)
-                    X_contextual = batch_samples['X_contextual']
+                if "labels" in batch_samples.keys():
+                    labels = batch_samples["labels"]
+                    labels = labels.to(self.device)
+                    labels = labels.reshape(labels.shape[0], -1)
+                else:
+                    labels = None
 
-                    if "labels" in batch_samples.keys():
-                        labels = batch_samples["labels"]
-                        labels = labels.to(self.device)
-                        labels = labels.reshape(labels.shape[0], -1)
-                    else:
-                        labels = None
+                if self.USE_CUDA:
+                    X_bow = X_bow.cuda()
+                    X_contextual = X_contextual.cuda()
 
-                    if self.USE_CUDA:
-                        X_bow = X_bow.cuda()
-                        X_contextual = X_contextual.cuda()
+                # forward pass
+                self.model.zero_grad()
+                mu, log_sig = self.model.get_posterior(X_bow, X_contextual, labels)
+                thetas = self.model.sample(mu, log_sig, n_samples).cpu().numpy()
+                final_thetas.append(thetas)
+        return np.concatenate(final_thetas, axis=0)
 
-                    # forward pass
-                    self.model.zero_grad()
-                    collect_theta.extend(self.model.get_theta(X_bow, X_contextual, labels).cpu().numpy().tolist())
+    def get_doc_topic_distribution_iterator(self, dataset, n_samples=20):
+        """
+        Get the document-topic distribution for a dataset of topics. Includes multiple sampling to reduce variation via
+        the parameter n_sample. Returns an iterator over the document-topic distributions.
 
-                pbar.update(1)
-                pbar.set_description("Sampling: [{}/{}]".format(sample_index + 1, n_samples))
+        :param dataset: a PyTorch Dataset containing the documents
+        :param n_samples: the number of sample to collect to estimate the final distribution (the more the better).
+        """
+        self.model.eval()
 
-                final_thetas.append(np.array(collect_theta))
-        pbar.close()
-        return np.sum(final_thetas, axis=0) / n_samples
+        loader = DataLoader(
+            dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=self.num_data_loader_workers,
+        )
+        with torch.no_grad():
+            for batch_samples in tqdm(loader, position=0, leave=True):
+                # batch_size x vocab_size
+                X_bow = batch_samples["X_bow"]
+                X_bow = X_bow.reshape(X_bow.shape[0], -1)
+                X_contextual = batch_samples["X_contextual"]
+
+                if "labels" in batch_samples.keys():
+                    labels = batch_samples["labels"]
+                    labels = labels.to(self.device)
+                    labels = labels.reshape(labels.shape[0], -1)
+                else:
+                    labels = None
+
+                if self.USE_CUDA:
+                    X_bow = X_bow.cuda()
+                    X_contextual = X_contextual.cuda()
+
+                # forward pass
+                self.model.zero_grad()
+                mu, log_sig = self.model.get_posterior(X_bow, X_contextual, labels)
+                thetas = self.model.sample(mu, log_sig, n_samples).cpu().numpy()
+                for theta in thetas:
+                    yield theta
 
     def get_most_likely_topic(self, doc_topic_distribution):
-        """ get the most likely topic for each document
+        """get the most likely topic for each document
 
         :param doc_topic_distribution: ndarray representing the topic distribution of each document
         """
@@ -433,8 +596,7 @@ class CTM:
         topics = defaultdict(list)
         for i in range(self.n_components):
             _, idxs = torch.topk(component_dists[i], k)
-            component_words = [self.idx2token[idx]
-                               for idx in idxs.cpu().numpy()]
+            component_words = [self.idx2token[idx] for idx in idxs.cpu().numpy()]
             topics[i] = component_words
         return topics
 
@@ -450,17 +612,23 @@ class CTM:
         topics = []
         for i in range(self.n_components):
             _, idxs = torch.topk(component_dists[i], k)
-            component_words = [self.idx2token[idx]
-                               for idx in idxs.cpu().numpy()]
+            component_words = [self.idx2token[idx] for idx in idxs.cpu().numpy()]
             topics.append(component_words)
         return topics
 
     def _format_file(self):
-        model_dir = "contextualized_topic_model_nc_{}_tpm_{}_tpv_{}_hs_{}_ac_{}_do_{}_lr_{}_mo_{}_rp_{}". \
-            format(self.n_components, 0.0, 1 - (1. / self.n_components),
-                   self.model_type, self.hidden_sizes, self.activation,
-                   self.dropout, self.lr, self.momentum,
-                   self.reduce_on_plateau)
+        model_dir = "contextualized_topic_model_nc_{}_tpm_{}_tpv_{}_hs_{}_ac_{}_do_{}_lr_{}_mo_{}_rp_{}".format(
+            self.n_components,
+            0.0,
+            1 - (1.0 / self.n_components),
+            self.model_type,
+            self.hidden_sizes,
+            self.activation,
+            self.dropout,
+            self.lr,
+            self.momentum,
+            self.reduce_on_plateau,
+        )
         return model_dir
 
     def save(self, models_dir=None):
@@ -469,10 +637,12 @@ class CTM:
 
         :param models_dir: path to directory for saving NN models.
         """
-        warnings.simplefilter('always', Warning)
-        warnings.warn("This is an experimental feature that we has not been fully tested. Refer to the following issue:"
-                      "https://github.com/MilaNLProc/contextualized-topic-models/issues/38",
-                      Warning)
+        warnings.simplefilter("always", Warning)
+        warnings.warn(
+            "This is an experimental feature that we has not been fully tested. Refer to the following issue:"
+            "https://github.com/MilaNLProc/contextualized-topic-models/issues/38",
+            Warning,
+        )
 
         if (self.model is not None) and (models_dir is not None):
 
@@ -480,11 +650,13 @@ class CTM:
             if not os.path.isdir(os.path.join(models_dir, model_dir)):
                 os.makedirs(os.path.join(models_dir, model_dir))
 
-            filename = "epoch_{}".format(self.nn_epoch) + '.pth'
+            filename = "epoch_{}".format(self.nn_epoch) + ".pth"
             fileloc = os.path.join(models_dir, model_dir, filename)
-            with open(fileloc, 'wb') as file:
-                torch.save({'state_dict': self.model.state_dict(),
-                            'dcue_dict': self.__dict__}, file)
+            with open(fileloc, "wb") as file:
+                torch.save(
+                    {"state_dict": self.model.state_dict(), "dcue_dict": self.__dict__},
+                    file,
+                )
 
     def load(self, model_dir, epoch):
         """
@@ -494,20 +666,22 @@ class CTM:
         :param epoch: epoch of model to load.
         """
 
-        warnings.simplefilter('always', Warning)
-        warnings.warn("This is an experimental feature that we has not been fully tested. Refer to the following issue:"
-                      "https://github.com/MilaNLProc/contextualized-topic-models/issues/38",
-                      Warning)
+        warnings.simplefilter("always", Warning)
+        warnings.warn(
+            "This is an experimental feature that we has not been fully tested. Refer to the following issue:"
+            "https://github.com/MilaNLProc/contextualized-topic-models/issues/38",
+            Warning,
+        )
 
         epoch_file = "epoch_" + str(epoch) + ".pth"
         model_file = os.path.join(model_dir, epoch_file)
-        with open(model_file, 'rb') as model_dict:
+        with open(model_file, "rb") as model_dict:
             checkpoint = torch.load(model_dict, map_location=torch.device(self.device))
 
-        for (k, v) in checkpoint['dcue_dict'].items():
+        for (k, v) in checkpoint["dcue_dict"].items():
             setattr(self, k, v)
 
-        self.model.load_state_dict(checkpoint['state_dict'])
+        self.model.load_state_dict(checkpoint["state_dict"])
 
     def get_topic_word_matrix(self):
         """
@@ -532,14 +706,16 @@ class CTM:
         :returns list of tuples (word, probability) sorted by the probability in descending order
         """
         if topic >= self.n_components:
-            raise Exception('Topic id must be lower than the number of topics')
+            raise Exception("Topic id must be lower than the number of topics")
         else:
             wd = self.get_topic_word_distribution()
             t = [(word, wd[topic][idx]) for idx, word in self.idx2token.items()]
             t = sorted(t, key=lambda x: -x[1])
         return t
 
-    def get_wordcloud(self, topic_id, n_words=5, background_color="black", width=1000, height=400):
+    def get_wordcloud(
+        self, topic_id, n_words=5, background_color="black", width=1000, height=400
+    ):
         """
         Plotting the wordcloud. It is an adapted version of the code found here:
         http://amueller.github.io/word_cloud/auto_examples/simple.html#sphx-glr-auto-examples-simple-py and
@@ -555,9 +731,12 @@ class CTM:
         word_score_dict = {tup[0]: tup[1] for tup in word_score_list}
         plt.figure(figsize=(10, 4), dpi=200)
         plt.axis("off")
-        plt.imshow(wordcloud.WordCloud(width=width, height=height, background_color=background_color
-                                       ).generate_from_frequencies(word_score_dict))
-        plt.title("Displaying Topic " + str(topic_id), loc='center', fontsize=24)
+        plt.imshow(
+            wordcloud.WordCloud(
+                width=width, height=height, background_color=background_color
+            ).generate_from_frequencies(word_score_dict)
+        )
+        plt.title("Displaying Topic " + str(topic_id), loc="center", fontsize=24)
         plt.show()
 
     def get_predicted_topics(self, dataset, n_samples):
@@ -584,28 +763,35 @@ class CTM:
         term_frequency = np.ravel(dataset.X_bow.sum(axis=0))
         doc_lengths = np.ravel(dataset.X_bow.sum(axis=1))
         term_topic = self.get_topic_word_distribution()
-        doc_topic_distribution = self.get_doc_topic_distribution(dataset, n_samples=n_samples)
+        doc_topic_distribution = self.get_doc_topic_distribution(
+            dataset, n_samples=n_samples
+        )
 
-        data = {'topic_term_dists': term_topic,
-                'doc_topic_dists': doc_topic_distribution,
-                'doc_lengths': doc_lengths,
-                'vocab': vocab,
-                'term_frequency': term_frequency}
+        data = {
+            "topic_term_dists": term_topic,
+            "doc_topic_dists": doc_topic_distribution,
+            "doc_lengths": doc_lengths,
+            "vocab": vocab,
+            "term_frequency": term_frequency,
+        }
 
         return data
 
-    def get_top_documents_per_topic_id(self, unpreprocessed_corpus, document_topic_distributions, topic_id, k=5):
+    def get_top_documents_per_topic_id(
+        self, unpreprocessed_corpus, document_topic_distributions, topic_id, k=5
+    ):
         probability_list = document_topic_distributions.T[topic_id]
         ind = probability_list.argsort()[-k:][::-1]
         res = []
         for i in ind:
-            res.append((unpreprocessed_corpus[i], document_topic_distributions[i][topic_id]))
+            res.append(
+                (unpreprocessed_corpus[i], document_topic_distributions[i][topic_id])
+            )
         return res
 
-class ZeroShotTM(CTM):
-    """ZeroShotTM, as described in https://arxiv.org/pdf/2004.07737v1.pdf
 
-    """
+class ZeroShotTM(CTM):
+    """ZeroShotTM, as described in https://arxiv.org/pdf/2004.07737v1.pdf"""
 
     def __init__(self, **kwargs):
         inference_type = "zeroshot"
@@ -613,9 +799,7 @@ class ZeroShotTM(CTM):
 
 
 class CombinedTM(CTM):
-    """CombinedTM, as described in https://arxiv.org/pdf/2004.03974.pdf
-
-    """
+    """CombinedTM, as described in https://arxiv.org/pdf/2004.03974.pdf"""
 
     def __init__(self, **kwargs):
         inference_type = "combined"

--- a/contextualized_topic_models/models/ctm.py
+++ b/contextualized_topic_models/models/ctm.py
@@ -554,7 +554,7 @@ class CTM:
             num_workers=self.num_data_loader_workers,
         )
         with torch.no_grad():
-            for batch_samples in tqdm(loader):
+            for batch_samples in loader:
                 # batch_size x vocab_size
                 X_bow = batch_samples["X_bow"]
                 X_bow = X_bow.reshape(X_bow.shape[0], -1)

--- a/contextualized_topic_models/models/ctm.py
+++ b/contextualized_topic_models/models/ctm.py
@@ -532,8 +532,8 @@ class CTM:
 
                 # forward pass
                 self.model.zero_grad()
-                mu, log_sig = self.model.get_posterior(X_bow, X_contextual, labels)
-                thetas = self.model.sample(mu, log_sig, n_samples).cpu().numpy()
+                mu, log_var = self.model.get_posterior(X_bow, X_contextual, labels)
+                thetas = self.model.sample(mu, log_var, n_samples).cpu().numpy()
                 final_thetas.append(thetas)
         return np.concatenate(final_thetas, axis=0)
 
@@ -573,8 +573,8 @@ class CTM:
 
                 # forward pass
                 self.model.zero_grad()
-                mu, log_sig = self.model.get_posterior(X_bow, X_contextual, labels)
-                thetas = self.model.sample(mu, log_sig, n_samples).cpu().numpy()
+                mu, log_var = self.model.get_posterior(X_bow, X_contextual, labels)
+                thetas = self.model.sample(mu, log_var, n_samples).cpu().numpy()
                 for theta in thetas:
                     yield theta
 

--- a/contextualized_topic_models/models/ctm.py
+++ b/contextualized_topic_models/models/ctm.py
@@ -513,7 +513,7 @@ class CTM:
         )
         final_thetas = []
         with torch.no_grad():
-            for batch_samples in tqdm(loader, position=0, leave=True):
+            for batch_samples in tqdm(loader):
                 # batch_size x vocab_size
                 X_bow = batch_samples["X_bow"]
                 X_bow = X_bow.reshape(X_bow.shape[0], -1)

--- a/contextualized_topic_models/models/ctm.py
+++ b/contextualized_topic_models/models/ctm.py
@@ -344,7 +344,6 @@ class CTM:
         )
 
         # init training variables
-        train_loss = 0
         samples_processed = 0
 
         # train loop
@@ -741,7 +740,7 @@ class CTM:
 
     def get_predicted_topics(self, dataset, n_samples):
         """
-        Return the a list containing the predicted topic for each document (length: number of documents).
+        Return the list containing the predicted topic for each document (length: number of documents).
 
         :param dataset: CTMDataset to infer topics
         :param n_samples: number of sampling of theta

--- a/contextualized_topic_models/networks/decoding_network.py
+++ b/contextualized_topic_models/networks/decoding_network.py
@@ -2,15 +2,26 @@ import torch
 from torch import nn
 from torch.nn import functional as F
 
-from contextualized_topic_models.networks.inference_network import CombinedInferenceNetwork, ContextualInferenceNetwork
+from contextualized_topic_models.networks.inference_network import (
+    CombinedInferenceNetwork,
+    ContextualInferenceNetwork,
+)
 
 
 class DecoderNetwork(nn.Module):
-
-
-    def __init__(self, input_size, bert_size, infnet, n_components=10, model_type='prodLDA',
-                 hidden_sizes=(100,100), activation='softplus', dropout=0.2,
-                 learn_priors=True, label_size=0):
+    def __init__(
+        self,
+        input_size,
+        bert_size,
+        infnet,
+        n_components=10,
+        model_type="prodLDA",
+        hidden_sizes=(100, 100),
+        activation="softplus",
+        dropout=0.2,
+        learn_priors=True,
+        label_size=0,
+    ):
         """
         Initialize InferenceNetwork.
 
@@ -24,14 +35,15 @@ class DecoderNetwork(nn.Module):
         """
         super(DecoderNetwork, self).__init__()
         assert isinstance(input_size, int), "input_size must by type int."
-        assert isinstance(n_components, int) and n_components > 0, \
-            "n_components must be type int > 0."
-        assert model_type in ['prodLDA', 'LDA'], \
-            "model type must be 'prodLDA' or 'LDA'"
-        assert isinstance(hidden_sizes, tuple), \
-            "hidden_sizes must be type tuple."
-        assert activation in ['softplus', 'relu'], \
-            "activation must be 'softplus' or 'relu'."
+        assert (
+            isinstance(n_components, int) and n_components > 0
+        ), "n_components must be type int > 0."
+        assert model_type in ["prodLDA", "LDA"], "model type must be 'prodLDA' or 'LDA'"
+        assert isinstance(hidden_sizes, tuple), "hidden_sizes must be type tuple."
+        assert activation in [
+            "softplus",
+            "relu",
+        ], "activation must be 'softplus' or 'relu'."
         assert dropout >= 0, "dropout must be >= 0."
 
         self.input_size = input_size
@@ -43,15 +55,28 @@ class DecoderNetwork(nn.Module):
         self.learn_priors = learn_priors
         self.topic_word_matrix = None
 
-
         if infnet == "zeroshot":
             self.inf_net = ContextualInferenceNetwork(
-                input_size, bert_size, n_components, hidden_sizes, activation, label_size=label_size)
+                input_size,
+                bert_size,
+                n_components,
+                hidden_sizes,
+                activation,
+                label_size=label_size,
+            )
         elif infnet == "combined":
             self.inf_net = CombinedInferenceNetwork(
-                input_size, bert_size, n_components, hidden_sizes, activation, label_size=label_size)
+                input_size,
+                bert_size,
+                n_components,
+                hidden_sizes,
+                activation,
+                label_size=label_size,
+            )
         else:
-            raise Exception('Missing infnet parameter, options are zeroshot and combined')
+            raise Exception(
+                "Missing infnet parameter, options are zeroshot and combined"
+            )
 
         if label_size != 0:
             self.label_classification = nn.Linear(n_components, label_size)
@@ -60,8 +85,7 @@ class DecoderNetwork(nn.Module):
         # \mu_1k = log \alpha_k + 1/K \sum_i log \alpha_i;
         # \alpha = 1 \forall \alpha
         topic_prior_mean = 0.0
-        self.prior_mean = torch.tensor(
-            [topic_prior_mean] * n_components)
+        self.prior_mean = torch.tensor([topic_prior_mean] * n_components)
         if torch.cuda.is_available():
             self.prior_mean = self.prior_mean.cuda()
         if self.learn_priors:
@@ -69,9 +93,8 @@ class DecoderNetwork(nn.Module):
 
         # \Sigma_1kk = 1 / \alpha_k (1 - 2/K) + 1/K^2 \sum_i 1 / \alpha_k;
         # \alpha = 1 \forall \alpha
-        topic_prior_variance = 1. - (1. / self.n_components)
-        self.prior_variance = torch.tensor(
-            [topic_prior_variance] * n_components)
+        topic_prior_variance = 1.0 - (1.0 / self.n_components)
+        self.prior_variance = torch.tensor([topic_prior_variance] * n_components)
         if torch.cuda.is_available():
             self.prior_variance = self.prior_variance.cuda()
         if self.learn_priors:
@@ -91,7 +114,7 @@ class DecoderNetwork(nn.Module):
     @staticmethod
     def reparameterize(mu, logvar):
         """Reparameterize the theta distribution."""
-        std = torch.exp(0.5*logvar)
+        std = torch.exp(0.5 * logvar)
         eps = torch.randn_like(std)
         return eps.mul(std).add_(mu)
 
@@ -102,18 +125,18 @@ class DecoderNetwork(nn.Module):
         posterior_sigma = torch.exp(posterior_log_sigma)
 
         # generate samples from theta
-        theta = F.softmax(
-            self.reparameterize(posterior_mu, posterior_log_sigma), dim=1)
+        theta = F.softmax(self.reparameterize(posterior_mu, posterior_log_sigma), dim=1)
         theta = self.drop_theta(theta)
 
         # prodLDA vs LDA
-        if self.model_type == 'prodLDA':
+        if self.model_type == "prodLDA":
             # in: batch_size x input_size x n_components
             word_dist = F.softmax(
-                self.beta_batchnorm(torch.matmul(theta, self.beta)), dim=1)
+                self.beta_batchnorm(torch.matmul(theta, self.beta)), dim=1
+            )
             # word_dist: batch_size x input_size
             self.topic_word_matrix = self.beta
-        elif self.model_type == 'LDA':
+        elif self.model_type == "LDA":
             # simplex constrain on Beta
             beta = F.softmax(self.beta_batchnorm(self.beta), dim=1)
             self.topic_word_matrix = beta
@@ -129,17 +152,52 @@ class DecoderNetwork(nn.Module):
         if labels is not None:
             estimated_labels = self.label_classification(theta)
 
-        return self.prior_mean, self.prior_variance, \
-            posterior_mu, posterior_sigma, posterior_log_sigma, word_dist, estimated_labels
+        return (
+            self.prior_mean,
+            self.prior_variance,
+            posterior_mu,
+            posterior_sigma,
+            posterior_log_sigma,
+            word_dist,
+            estimated_labels,
+        )
+
+    def get_posterior(self, x, x_bert, labels=None):
+        """Get posterior distribution."""
+        # batch_size x n_components
+        posterior_mu, posterior_log_sigma = self.inf_net(x, x_bert, labels)
+
+        return posterior_mu, posterior_log_sigma
 
     def get_theta(self, x, x_bert, labels=None):
         with torch.no_grad():
             # batch_size x n_components
-            posterior_mu, posterior_log_sigma = self.inf_net(x, x_bert, labels)
-            #posterior_sigma = torch.exp(posterior_log_sigma)
+            posterior_mu, posterior_log_sigma = self.get_posterior(x, x_bert, labels)
+            # posterior_sigma = torch.exp(posterior_log_sigma)
 
             # generate samples from theta
             theta = F.softmax(
-                self.reparameterize(posterior_mu, posterior_log_sigma), dim=1)
+                self.reparameterize(posterior_mu, posterior_log_sigma), dim=1
+            )
 
             return theta
+
+    def get_sample(self, posterior_mu, posterior_log_sigma):
+        with torch.no_grad():
+            # generate samples from theta
+            theta = F.softmax(
+                self.reparameterize(posterior_mu, posterior_log_sigma), dim=1
+            )
+
+            return theta
+
+    def sample(self, posterior_mu, posterior_log_sigma, n_samples: int = 20):
+        with torch.no_grad():
+            posterior_mu = posterior_mu.unsqueeze(0).repeat(n_samples, 1, 1)
+            posterior_log_sigma = posterior_log_sigma.unsqueeze(0).repeat(n_samples, 1, 1)
+            # generate samples from theta
+            theta = F.softmax(
+                self.reparameterize(posterior_mu, posterior_log_sigma), dim=-1
+            )
+
+            return theta.mean(dim=0)

--- a/contextualized_topic_models/networks/decoding_network.py
+++ b/contextualized_topic_models/networks/decoding_network.py
@@ -182,15 +182,6 @@ class DecoderNetwork(nn.Module):
 
             return theta
 
-    def get_sample(self, posterior_mu, posterior_log_sigma):
-        with torch.no_grad():
-            # generate samples from theta
-            theta = F.softmax(
-                self.reparameterize(posterior_mu, posterior_log_sigma), dim=1
-            )
-
-            return theta
-
     def sample(self, posterior_mu, posterior_log_sigma, n_samples: int = 20):
         with torch.no_grad():
             posterior_mu = posterior_mu.unsqueeze(0).repeat(n_samples, 1, 1)


### PR DESCRIPTION
I regularly ran out of memory on large datasets during the CTM fit call. Upon further inspection, I found the automatic generation of training_doc_topic_distributions with get_doc_topic_distribution after the fit call to have many opportunities for improved memory usage. I made the following changes:

1. Made generating the training_doc_topic_distributions optional at the end of the fit call, defaulting to True
2. Removed the n_samples loop from the get_doc_topic_distribution operation
3. Reused the posterior_mu, posterior_log_sigma across samples, as they remain the same
4. Vectorized the sampling process on GPU
5. Added a get_doc_topic_distribution_iterator operation, which significantly saves memory if the dataset is large by computing topics one batch at a time and yielding them as an iterator
6. Formatted the ctm.py and decoding_network.py with black, for easier visibility

I do not believe any of the changes I made are breaking changes, these should simply make topic discovery run faster and with less memory.

These efficiency gains enabled me to run the CTM on a massive collection of tweets, so I thought I would create a pull request and offer these improvements back to the original repo, as it still seems active.