### PR TITLE
Allow setting a fixed symmetric alpha for the Dirichlet prior

### DIFF
--- a/contextualized_topic_models/models/ctm.py
+++ b/contextualized_topic_models/models/ctm.py
@@ -40,6 +40,7 @@ class CTM:
     :param num_data_loader_workers: int, number of data loader workers (default cpu_count). set it to 0 if you are using Windows
     :param label_size: int, number of total labels (default: 0)
     :param loss_weights: dict, it contains the name of the weight parameter (key) and the weight (value) for each loss.
+    :param prior_alpha: float, fixed symmetric alpha for the Dirichlet prior. if learn_priors == True, only used to initialize prior_variance (default 1.0)
     It supports only the weight parameter beta for now. If None, then the weights are set to 1 (default: None).
 
     """
@@ -64,6 +65,7 @@ class CTM:
         num_data_loader_workers=mp.cpu_count(),
         label_size=0,
         loss_weights=None,
+        prior_alpha=1.0,
     ):
 
         self.device = (
@@ -101,6 +103,9 @@ class CTM:
         assert (
             isinstance(num_data_loader_workers, int) and num_data_loader_workers >= 0
         ), "num_data_loader_workers must by type int >= 0. set 0 if you are using windows"
+        assert (
+            isinstance(prior_alpha, float) and prior_alpha > 0
+        ), "prior_alpha must be type float > 0."
 
         self.bow_size = bow_size
         self.n_components = n_components
@@ -118,6 +123,7 @@ class CTM:
         self.reduce_on_plateau = reduce_on_plateau
         self.num_data_loader_workers = num_data_loader_workers
         self.training_doc_topic_distributions = None
+        self.prior_alpha = prior_alpha
 
         if loss_weights:
             self.weights = loss_weights
@@ -135,6 +141,7 @@ class CTM:
             dropout,
             learn_priors,
             label_size=label_size,
+            prior_alpha=prior_alpha,
         )
 
         self.early_stopping = None
@@ -308,6 +315,7 @@ class CTM:
                    Activation: {}\n\
                    Dropout: {}\n\
                    Learn Priors: {}\n\
+                   Prior Alpha: {}\n\
                    Learning Rate: {}\n\
                    Momentum: {}\n\
                    Reduce On Plateau: {}\n\
@@ -320,6 +328,7 @@ class CTM:
                     self.activation,
                     self.dropout,
                     self.learn_priors,
+                    self.prior_alpha,
                     self.lr,
                     self.momentum,
                     self.reduce_on_plateau,

--- a/contextualized_topic_models/models/ctm.py
+++ b/contextualized_topic_models/models/ctm.py
@@ -322,7 +322,7 @@ class CTM:
                    Save Dir: {}".format(
                     self.n_components,
                     0.0,
-                    1.0 - (1.0 / self.n_components),
+                    (1.0 / self.prior_alpha) * (1.0 - (1.0 / self.n_components)),
                     self.model_type,
                     self.hidden_sizes,
                     self.activation,
@@ -628,7 +628,7 @@ class CTM:
         model_dir = "contextualized_topic_model_nc_{}_tpm_{}_tpv_{}_hs_{}_ac_{}_do_{}_lr_{}_mo_{}_rp_{}".format(
             self.n_components,
             0.0,
-            1 - (1.0 / self.n_components),
+            (1.0 / self.prior_alpha) * (1.0 - (1.0 / self.n_components)),
             self.model_type,
             self.hidden_sizes,
             self.activation,

--- a/contextualized_topic_models/networks/decoding_network.py
+++ b/contextualized_topic_models/networks/decoding_network.py
@@ -21,6 +21,7 @@ class DecoderNetwork(nn.Module):
         dropout=0.2,
         learn_priors=True,
         label_size=0,
+        prior_alpha=1.0,
     ):
         """
         Initialize InferenceNetwork.
@@ -32,6 +33,7 @@ class DecoderNetwork(nn.Module):
             hidden_sizes : tuple, length = n_layers, (default (100, 100))
             activation : string, 'softplus', 'relu', (default 'softplus')
             learn_priors : bool, make priors learnable parameter
+            prior_alpha : float, fixed symmetric Dirichlet hyperparameter (default 1.0)
         """
         super(DecoderNetwork, self).__init__()
         assert isinstance(input_size, int), "input_size must by type int."
@@ -45,6 +47,9 @@ class DecoderNetwork(nn.Module):
             "relu",
         ], "activation must be 'softplus' or 'relu'."
         assert dropout >= 0, "dropout must be >= 0."
+        assert (
+            isinstance(prior_alpha, float) and prior_alpha > 0
+        ), "prior_alpha must be type float > 0."
 
         self.input_size = input_size
         self.n_components = n_components
@@ -53,6 +58,7 @@ class DecoderNetwork(nn.Module):
         self.activation = activation
         self.dropout = dropout
         self.learn_priors = learn_priors
+        self.prior_alpha = prior_alpha
         self.topic_word_matrix = None
 
         if infnet == "zeroshot":
@@ -92,8 +98,8 @@ class DecoderNetwork(nn.Module):
             self.prior_mean = nn.Parameter(self.prior_mean)
 
         # \Sigma_1kk = 1 / \alpha_k (1 - 2/K) + 1/K^2 \sum_i 1 / \alpha_k;
-        # \alpha = 1 \forall \alpha
-        topic_prior_variance = 1.0 - (1.0 / self.n_components)
+        # \alpha = self.prior_alpha \forall \alpha
+        topic_prior_variance = (1.0 / self.prior_alpha) * (1.0 - (1.0 / self.n_components))
         self.prior_variance = torch.tensor([topic_prior_variance] * n_components)
         if torch.cuda.is_available():
             self.prior_variance = self.prior_variance.cuda()

--- a/contextualized_topic_models/networks/decoding_network.py
+++ b/contextualized_topic_models/networks/decoding_network.py
@@ -89,7 +89,7 @@ class DecoderNetwork(nn.Module):
 
         # init prior parameters
         # \mu_1k = log \alpha_k + 1/K \sum_i log \alpha_i;
-        # \alpha = 1 \forall \alpha
+        # \alpha = self.prior_alpha \forall \alpha
         topic_prior_mean = 0.0
         self.prior_mean = torch.tensor([topic_prior_mean] * n_components)
         if torch.cuda.is_available():


### PR DESCRIPTION
Made a relatively small change in the variance approximation formula to allow an arbitrary symmetric alpha instead of alpha=1 when learn_priors=False. But added a new parameter prior_alpha, so had to make quite a few edits. 